### PR TITLE
Added vendor cache to bitbucket-pipelines configuration.

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -4,6 +4,7 @@ pipelines:
     - step:
         caches:
           - composer
+          - vendor
         script:
           # Show software versions.
           - composer self-update


### PR DESCRIPTION
Even though this package is on GitHub, it's regularly used in combination with Bitbucket Pipelines. Adding vendor cache speeds this up considerably.