### PR TITLE
1.6.1 Require stable versions of phpstan and grumphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
         "mediact/coding-standard-phpstorm": "@stable",
         "phpunit/phpunit": "@stable",
         "kint-php/kint": "@stable",
-        "phpstan/phpstan": "^0.6.4",
+        "phpstan/phpstan": "@stable",
         "composer-plugin-api": "^1.1",
         "mediact/composer-dependency-installer": "^1.0",
         "mediact/composer-file-installer": "^1.0",
-        "phpro/grumphp": "^0.11.6"
+        "phpro/grumphp": "@stable"
     },
     "require-dev": {
         "composer/composer": "@stable",


### PR DESCRIPTION
The version constraints that were used do not work well with 0.* releases. New versions of both packages have been released (0.8.5 and 0.12.1) but the testing suite was still using 0.6.4 and 0.11.6. Requiring `@stable` fixes this.