### PR TITLE
Remove TestFramework and Factory errors in PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
 parameters:
   excludes_analyse:
     - src/installers.php
+  ignoreErrors:
+    - '#(class|type) Magento\\TestFramework#i'
+    - '#(class|type) Magento\\\S*Factory#i'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,3 @@
 parameters:
   excludes_analyse:
     - src/installers.php
-  ignoreErrors:
-    - '#(class|type) Magento\\TestFramework#i'
-    - '#(class|type) Magento\\\S*Factory#i'

--- a/templates/files/magento2/phpstan.neon
+++ b/templates/files/magento2/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+  excludes_analyse:
+#    - %rootDir%/../../../path/to/exclude/*
+  ignoreErrors:
+    - '#(class|type) Magento\\TestFramework#i'
+    - '#(class|type) Magento\\\S*Factory#i'

--- a/templates/files/magento2/phpstan.neon
+++ b/templates/files/magento2/phpstan.neon
@@ -1,6 +1,4 @@
 parameters:
-  excludes_analyse:
-#    - %rootDir%/../../../path/to/exclude/*
   ignoreErrors:
     - '#(class|type) Magento\\TestFramework#i'
     - '#(class|type) Magento\\\S*Factory#i'

--- a/templates/mapping/project/magento2
+++ b/templates/mapping/project/magento2
@@ -1,1 +1,2 @@
 {magento2/,}phpcs.xml
+{magento2/,}phpstan.neon


### PR DESCRIPTION
Since TestFramework and Factory classes are used in quite some
extensions, but are dynamically generated by Magento by running the
Magento 2 setup, this will result in several errors when checking
your extension with the testing suite.

Source: https://github.com/tddwizard/magento2-fixtures/blob/master/phpstan.neon