### PR TITLE
Composer 1.6 & Symfony 4.0 compatibility 

### DIFF
--- a/src/Factory/ProcessFactory.php
+++ b/src/Factory/ProcessFactory.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\TestingSuite\Composer\Factory;
+
+use Symfony\Component\Process\Process;
+
+class ProcessFactory implements ProcessFactoryInterface
+{
+    /**
+     * Create a new Process instance.
+     *
+     * @param string $commandLine
+     *
+     * @return Process
+     */
+    public function create(string $commandLine): Process
+    {
+        return new Process($commandLine);
+    }
+}

--- a/src/Factory/ProcessFactoryInterface.php
+++ b/src/Factory/ProcessFactoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\TestingSuite\Composer\Factory;
+
+use Symfony\Component\Process\Process;
+
+interface ProcessFactoryInterface
+{
+    /**
+     * Create a new Process instance.
+     *
+     * @param string $commandLine
+     *
+     * @return Process
+     */
+    public function create(string $commandLine): Process;
+}

--- a/src/Installer/PipelinesInstaller.php
+++ b/src/Installer/PipelinesInstaller.php
@@ -108,7 +108,8 @@ class PipelinesInstaller implements InstallerInterface
             key($labels)
         );
 
-        return $keys[$selected];
+        return is_numeric($selected) ? $keys[$selected]
+            : array_search($selected, $this->types);
     }
 
     /**

--- a/src/Installer/PipelinesInstaller.php
+++ b/src/Installer/PipelinesInstaller.php
@@ -9,7 +9,7 @@ namespace Mediact\TestingSuite\Composer\Installer;
 use Composer\IO\IOInterface;
 use Mediact\Composer\FileInstaller;
 use Mediact\FileMapping\UnixFileMapping;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 class PipelinesInstaller implements InstallerInterface
 {
@@ -18,9 +18,6 @@ class PipelinesInstaller implements InstallerInterface
 
     /** @var IOInterface */
     private $io;
-
-    /** @var ProcessBuilder */
-    private $processBuilder;
 
     /** @var string */
     private $destination;
@@ -42,7 +39,6 @@ class PipelinesInstaller implements InstallerInterface
      *
      * @param FileInstaller  $fileInstaller
      * @param IOInterface    $io
-     * @param ProcessBuilder $processBuilder
      * @param string|null    $destination
      * @param string|null    $pattern
      * @param string|null    $filename
@@ -51,7 +47,6 @@ class PipelinesInstaller implements InstallerInterface
     public function __construct(
         FileInstaller $fileInstaller,
         IOInterface $io,
-        ProcessBuilder $processBuilder = null,
         string $destination = null,
         string $pattern = null,
         string $filename = null,
@@ -59,7 +54,6 @@ class PipelinesInstaller implements InstallerInterface
     ) {
         $this->fileInstaller  = $fileInstaller;
         $this->io             = $io;
-        $this->processBuilder = $processBuilder ?? new ProcessBuilder();
         $this->destination    = $destination ?? getcwd();
         $this->pattern        = $pattern ?? $this->pattern;
         $this->filename       = $filename ?? $this->filename;
@@ -124,11 +118,7 @@ class PipelinesInstaller implements InstallerInterface
      */
     private function isBitbucket(): bool
     {
-        $process = $this->processBuilder
-            ->setPrefix('/usr/bin/env')
-            ->setArguments(['git', 'remote', '-v'])
-            ->getProcess();
-
+        $process = new Process('git remote -v');
         $process->run();
 
         return strpos($process->getOutput(), $this->pattern) !== false;

--- a/src/Installer/PipelinesInstaller.php
+++ b/src/Installer/PipelinesInstaller.php
@@ -9,6 +9,7 @@ namespace Mediact\TestingSuite\Composer\Installer;
 use Composer\IO\IOInterface;
 use Mediact\Composer\FileInstaller;
 use Mediact\FileMapping\UnixFileMapping;
+use Mediact\TestingSuite\Composer\Factory\ProcessFactoryInterface;
 use Symfony\Component\Process\Process;
 
 class PipelinesInstaller implements InstallerInterface
@@ -18,6 +19,9 @@ class PipelinesInstaller implements InstallerInterface
 
     /** @var IOInterface */
     private $io;
+
+    /** @var ProcessFactoryInterface */
+    private $processFactory;
 
     /** @var string */
     private $destination;
@@ -37,16 +41,18 @@ class PipelinesInstaller implements InstallerInterface
     /**
      * Constructor.
      *
-     * @param FileInstaller  $fileInstaller
-     * @param IOInterface    $io
-     * @param string|null    $destination
-     * @param string|null    $pattern
-     * @param string|null    $filename
-     * @param array|null     $types
+     * @param FileInstaller           $fileInstaller
+     * @param IOInterface             $io
+     * @param ProcessFactoryInterface $processFactory
+     * @param string|null             $destination
+     * @param string|null             $pattern
+     * @param string|null             $filename
+     * @param array|null              $types
      */
     public function __construct(
         FileInstaller $fileInstaller,
         IOInterface $io,
+        ProcessFactoryInterface $processFactory,
         string $destination = null,
         string $pattern = null,
         string $filename = null,
@@ -54,6 +60,7 @@ class PipelinesInstaller implements InstallerInterface
     ) {
         $this->fileInstaller  = $fileInstaller;
         $this->io             = $io;
+        $this->processFactory = $processFactory;
         $this->destination    = $destination ?? getcwd();
         $this->pattern        = $pattern ?? $this->pattern;
         $this->filename       = $filename ?? $this->filename;
@@ -119,7 +126,7 @@ class PipelinesInstaller implements InstallerInterface
      */
     private function isBitbucket(): bool
     {
-        $process = new Process('git remote -v');
+        $process = $this->processFactory->create('git remote -v');
         $process->run();
 
         return strpos($process->getOutput(), $this->pattern) !== false;

--- a/src/installers.php
+++ b/src/installers.php
@@ -6,6 +6,7 @@
 
 use Mediact\Composer\FileInstaller;
 use Mediact\FileMapping\UnixFileMappingReader;
+use Mediact\TestingSuite\Composer\Factory\ProcessFactory;
 use Mediact\TestingSuite\Composer\Installer\ArchiveExcludeInstaller;
 use Mediact\TestingSuite\Composer\Installer\FilesInstaller;
 use Mediact\TestingSuite\Composer\Installer\GrumPhpInstaller;
@@ -24,11 +25,12 @@ $mappingResolver = new MappingResolver($typeResolver);
 $fileInstaller   = new FileInstaller(
     new UnixFileMappingReader('', '')
 );
+$processFactory  = new ProcessFactory();
 
 return [
     new FilesInstaller($mappingResolver, $fileInstaller, $io),
     new GrumPhpInstaller($io),
     new ArchiveExcludeInstaller($mappingResolver, $io),
     new PackagesInstaller($composer, $typeResolver, $io),
-    new PipelinesInstaller($fileInstaller, $io),
+    new PipelinesInstaller($fileInstaller, $io, $processFactory),
 ];

--- a/tests/Factory/ProcessFactoryTest.php
+++ b/tests/Factory/ProcessFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+namespace Mediact\TestingSuite\Composer\Tests\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Mediact\TestingSuite\Composer\Factory\ProcessFactory;
+use Symfony\Component\Process\Process;
+
+/**
+ * @coversDefaultClass \Mediact\TestingSuite\Composer\Factory\ProcessFactory
+ */
+class ProcessFactoryTest extends TestCase
+{
+    /**
+     * @return void
+     *
+     * @covers ::create
+     */
+    public function testCreate()
+    {
+        $factory = new ProcessFactory();
+
+        $this->assertInstanceOf(
+            Process::class,
+            $factory->create('foo')
+        );
+    }
+}

--- a/tests/Installer/PipelinesInstallerTest.php
+++ b/tests/Installer/PipelinesInstallerTest.php
@@ -8,6 +8,7 @@ namespace Mediact\TestingSuite\Composer\Tests\Installer;
 
 use Composer\IO\IOInterface;
 use Mediact\Composer\FileInstaller;
+use Mediact\TestingSuite\Composer\Factory\ProcessFactoryInterface;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
@@ -40,24 +41,9 @@ class PipelinesInstallerTest extends TestCase
     ) {
         $fileInstaller  = $this->createMock(FileInstaller::class);
         $io             = $this->createMock(IOInterface::class);
-        $processBuilder = $this->createMock(ProcessBuilder::class);
+        $processFactory = $this->createMock(ProcessFactoryInterface::class);
         $process        = $this->createMock(Process::class);
         $filesystem     = $this->createFilesystem($files);
-
-        $processBuilder
-            ->expects(self::any())
-            ->method('setPrefix')
-            ->willReturnSelf();
-
-        $processBuilder
-            ->expects(self::any())
-            ->method('setArguments')
-            ->willReturnSelf();
-
-        $processBuilder
-            ->expects(self::any())
-            ->method('getProcess')
-            ->willReturn($process);
 
         $process
             ->expects(self::any())
@@ -68,6 +54,11 @@ class PipelinesInstallerTest extends TestCase
             ->method('getOutput')
             ->willReturn($remotes);
 
+        $processFactory
+            ->expects(self::any())
+            ->method('create')
+            ->willReturn($process);
+
         if ($expectedInstall) {
             $fileInstaller
                 ->expects(self::once())
@@ -76,7 +67,7 @@ class PipelinesInstallerTest extends TestCase
             $io
                 ->expects(self::once())
                 ->method('select')
-                    ->willReturn('0');
+                ->willReturn('0');
         } else {
             $fileInstaller
                 ->expects(self::never())
@@ -86,7 +77,7 @@ class PipelinesInstallerTest extends TestCase
         $installer = new PipelinesInstaller(
             $fileInstaller,
             $io,
-            $processBuilder,
+            $processFactory,
             $filesystem->url()
         );
 


### PR DESCRIPTION
This pull request adds compatibility for Composer 1.6 and Symfony 4.0. 

- When asking a question using the console Composer 1.6 returns the selected answer while previous versions returns the array key index. Check the return type and return the chosen answer. 
- The deprecated class Symfony\Component\Process\ProcessBuilder is removed in Symfony 4.0. The Symfony\Component\Process\Process class is now used instead. 