### PR TITLE
Feature Made composer validate strict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
     ],
     "require": {
         "php": "^7.0",
-        "mediact/coding-standard": "@stable",
-        "mediact/coding-standard-phpstorm": "@stable",
-        "phpunit/phpunit": "@stable",
-        "kint-php/kint": "@stable",
-        "phpstan/phpstan": "@stable",
+        "mediact/coding-standard": "^2.0",
+        "mediact/coding-standard-phpstorm": "^1.5",
+        "phpunit/phpunit": "^6.5",
+        "kint-php/kint": "^2.2",
+        "phpstan/phpstan": "^0.9",
         "composer-plugin-api": "^1.1",
         "mediact/composer-dependency-installer": "^1.0",
         "mediact/composer-file-installer": "^1.0",
-        "phpro/grumphp": "@stable"
+        "phpro/grumphp": "^0.13"
     },
     "require-dev": {
         "composer/composer": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
     ],
     "require": {
         "php": "^7.0",
-        "mediact/coding-standard": "^2.0",
-        "mediact/coding-standard-phpstorm": "^1.5",
-        "phpunit/phpunit": "^6.5",
-        "kint-php/kint": "^2.2",
-        "phpstan/phpstan": "^0.9",
+        "mediact/coding-standard": "~1.0 || ~2.0",
+        "mediact/coding-standard-phpstorm": "~1.0",
+        "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
+        "kint-php/kint": "~1.0 || ~2.0",
+        "phpstan/phpstan": "~0.1",
         "composer-plugin-api": "^1.1",
         "mediact/composer-dependency-installer": "^1.0",
         "mediact/composer-file-installer": "^1.0",
-        "phpro/grumphp": "^0.13"
+        "phpro/grumphp": "~0.1"
     },
     "require-dev": {
         "composer/composer": "@stable",

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -6,6 +6,7 @@ parameters:
     succeeded: ~
   tasks:
     composer:
+      strict: true
       metadata:
         priority: 1000
     phpcs:


### PR DESCRIPTION
The reason for this is that the default pipeline also has this check built-in.

This way the testing-suite will give a more similar result to the pipelines.
I've also changed the composer.json file of the project, because it had @stable references in the requirements, this is not allowed anymore with the new setting.