### PR TITLE
Feature use wildcards for the namespaces for factory methods and the testframework

### DIFF
--- a/templates/files/magento2/phpstan.neon
+++ b/templates/files/magento2/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
   ignoreErrors:
-    - '#(class|type) Magento\\TestFramework#i'
-    - '#(class|type) Magento\\\S*Factory#i'
+    - '#(class|type) [A-z]*\\TestFramework#i'
+    - '#(class|type) [A-z]*\\\S*Factory#i'


### PR DESCRIPTION
Within different projects there can be a dependency to different factory methods within other vendor namespaces.

With this commit the vendor part of the namespaces are made up of a wildcard.
This way it does not have to be explicitly defined. In normal use-cases it wouldn't be an issue to do so, because the factories are automatically generated.

http://devdocs.magento.com/guides/v2.0/extension-dev-guide/factories.html#writing-factories