### PR TITLE
1.11.1 - Invalid file mapping

### DIFF
--- a/templates/mapping/project/magento1
+++ b/templates/mapping/project/magento1
@@ -1,4 +1,4 @@
 {magento1/,}phpcs.xml
 {magento1/,}package.json
 {magento1/,}.eslintrc.json
-{magento1/,}.eslintignore.json
+{magento1/,}.eslintignore

--- a/templates/mapping/project/magento2
+++ b/templates/mapping/project/magento2
@@ -2,4 +2,4 @@
 {magento2/,}phpstan.neon
 {magento2/,}package.json
 {magento2/,}.eslintrc.json
-{magento2/,}.eslintignore.json
+{magento2/,}.eslintignore


### PR DESCRIPTION
The mapping files of Magento 1 and Magento 2 projects contain invalid files. `.eslintignore.json` should be `.eslintignore`.