### PR TITLE
Bugfix: temporarily disable dependency guard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "mediact/coding-standard-phpstorm": "~1.0",
         "mediact/composer-dependency-installer": "^1.0",
         "mediact/composer-file-installer": "^1.0",
-        "mediact/dependency-guard": "^1.0",
         "phpro/grumphp": "~0.1",
         "phpstan/phpstan": "~0.1",
         "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0"

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -32,42 +32,42 @@ parameters:
       config_file: ./phpunit.xml
       metadata:
         priority: 200
-    dependency-guard:
-      metadata:
-        priority: 100
+#    dependency-guard:
+#      metadata:
+#        priority: 100
 
-services:
-  mediact.dependency_guard.exporter.factory:
-    class: Mediact\DependencyGuard\Composer\Command\Exporter\ViolationExporterFactory
-
-  mediact.dependency_guard.exporter:
-    class: Mediact\DependencyGuard\Exporter\ViolationExporterInterface
-    factory: 'mediact.dependency_guard.exporter.factory:create'
-    arguments:
-    - '@console.input'
-    - '@console.output'
-
-  mediact.dependency_guard.factory:
-    class: Mediact\DependencyGuard\DependencyGuardFactory
-
-  mediact.dependency_guard.composer.io:
-    class: Composer\IO\BufferIO
-
-  mediact.dependency_guard.composer.factory:
-    class: Composer\Factory
-
-  mediact.dependency_guard.composer:
-    class: Composer\Composer
-    factory: mediact.dependency_guard.composer.factory:createComposer
-    arguments:
-      - '@mediact.dependency_guard.composer.io'
-
-  mediact.dependency_guard.grumphp.task:
-    class: Mediact\DependencyGuard\GrumPHP\DependencyGuard
-    arguments:
-      - '@mediact.dependency_guard.composer'
-      - '@mediact.dependency_guard.factory'
-      - '@mediact.dependency_guard.exporter'
-    tags:
-      - name: grumphp.task
-        config: dependency-guard
+#services:
+#  mediact.dependency_guard.exporter.factory:
+#    class: Mediact\DependencyGuard\Composer\Command\Exporter\ViolationExporterFactory
+#
+#  mediact.dependency_guard.exporter:
+#    class: Mediact\DependencyGuard\Exporter\ViolationExporterInterface
+#    factory: 'mediact.dependency_guard.exporter.factory:create'
+#    arguments:
+#    - '@console.input'
+#    - '@console.output'
+#
+#  mediact.dependency_guard.factory:
+#    class: Mediact\DependencyGuard\DependencyGuardFactory
+#
+#  mediact.dependency_guard.composer.io:
+#    class: Composer\IO\BufferIO
+#
+#  mediact.dependency_guard.composer.factory:
+#    class: Composer\Factory
+#
+#  mediact.dependency_guard.composer:
+#    class: Composer\Composer
+#    factory: mediact.dependency_guard.composer.factory:createComposer
+#    arguments:
+#      - '@mediact.dependency_guard.composer.io'
+#
+#  mediact.dependency_guard.grumphp.task:
+#    class: Mediact\DependencyGuard\GrumPHP\DependencyGuard
+#    arguments:
+#      - '@mediact.dependency_guard.composer'
+#      - '@mediact.dependency_guard.factory'
+#      - '@mediact.dependency_guard.exporter'
+#    tags:
+#      - name: grumphp.task
+#        config: dependency-guard


### PR DESCRIPTION
Due to an issue in dependency guard, circular dependencies cause an infinite loop.
When this issue is fixed, it will be re-added.