### PR TITLE
1.19.1 Bugfix: pipelines check platform requirements sttep requires lock file

### DIFF
--- a/templates/files/default/bitbucket-pipelines.yml
+++ b/templates/files/default/bitbucket-pipelines.yml
@@ -11,7 +11,7 @@ pipelines:
           - vendor
         script:
           - composer self-update
-          - composer check-platform-reqs
+          - if [ -f "composer.lock" ]; then composer check-platform-reqs; fi
           - if [ -n "$COMPOSER_PRE_INSTALL_CALLBACK" ]; then eval $COMPOSER_PRE_INSTALL_CALLBACK; fi
           - composer install --dev --prefer-dist --no-scripts --no-progress --optimize-autoloader --no-interaction -vvv
           - composer show

--- a/templates/files/magento1/bitbucket-pipelines.yml
+++ b/templates/files/magento1/bitbucket-pipelines.yml
@@ -11,7 +11,7 @@ pipelines:
           - vendor
         script:
           - composer self-update
-          - composer check-platform-reqs
+          - if [ -f "composer.lock" ]; then composer check-platform-reqs; fi
           - if [ -n "$COMPOSER_PRE_INSTALL_CALLBACK" ]; then eval $COMPOSER_PRE_INSTALL_CALLBACK; fi
           - composer install --dev --prefer-dist --no-scripts --no-progress --optimize-autoloader --no-interaction -vvv
           - composer show

--- a/templates/files/magento2/bitbucket-pipelines.yml
+++ b/templates/files/magento2/bitbucket-pipelines.yml
@@ -11,7 +11,7 @@ pipelines:
           - vendor
         script:
           - composer self-update
-          - composer check-platform-reqs
+          - if [ -f "composer.lock" ]; then composer check-platform-reqs; fi
           - if [ -n "$COMPOSER_PRE_INSTALL_CALLBACK" ]; then eval $COMPOSER_PRE_INSTALL_CALLBACK; fi
           - composer install --dev --prefer-dist --no-scripts --no-progress --optimize-autoloader --no-interaction -vvv
           - composer show


### PR DESCRIPTION
Pipelines are failing for packages, because they do not have a lock file.

This is solved by checking if a lock file is present before check the platform requirements.