### PR TITLE
1.21.1 Require a 4.x version of Symfony DI to solve issue with pdepend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "phpro/grumphp": "~0.1",
         "phpstan/phpstan": "~0.1",
         "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
-        "sensiolabs/security-checker": "^5.0"
+        "sensiolabs/security-checker": "^5.0",
+        "symfony/dependency-injection": "^4.0"
     },
     "require-dev": {
         "composer/composer": "@stable",


### PR DESCRIPTION
The pdepend package accepts any version higher than 2.4 of symfony di
but is not compatible with 5.x. This line should be removed once
pdepend has released a new stable version.