### PR TITLE
1.21.3 Exclude grumphp 0.18.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "mediact/composer-dependency-installer": "^1.0",
         "mediact/composer-file-installer": "^1.0",
         "mediact/composer-unclog-plugin": "^1.0",
-        "phpro/grumphp": "~0.1",
+        "phpro/grumphp": "~0.1, !=0.18.0",
         "phpstan/phpstan": "~0.1",
         "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
         "sensiolabs/security-checker": "^5.0",


### PR DESCRIPTION
Grumphp 0.18.0 does not support parameters in the configuration of tasks.

> The option "strict" with value "%composer.strict%" is expected to be of type "bool", but is of type "string"