### PR TITLE
1.21.4 Require version 4 of Symfony event dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "phpstan/phpstan": "~0.1",
         "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
         "sensiolabs/security-checker": "^5.0",
+        "symfony/event-dispatcher": "^4.0",
         "symfony/dependency-injection": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
GrumPHP allows version 5 of the event dispatcher package but the verbose logger is not compatible with it.