### PR TITLE
1.22.0 Disable pdepend file cache

### DIFF
--- a/templates/files/default/pdepend.xml
+++ b/templates/files/default/pdepend.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<symfony:container xmlns:symfony="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://pdepend.org/schema/dic/pdepend"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <config>
+        <cache>
+            <driver>memory</driver>
+        </cache>
+    </config>
+</symfony:container>

--- a/templates/mapping/files
+++ b/templates/mapping/files
@@ -1,5 +1,6 @@
 {default/,}grumphp.yml
 {default/dot,.}gitignore
 {default/,}phpmd.xml
+{default/,}pdepend.xml
 {default/,}phpstan.neon
 {default/,}phpunit{_dist,}.xml


### PR DESCRIPTION
By using the memory cache implementation of pdepend it no longer stores
cache in ~/.pdepend. The file cache implementation has a garbage
collector for the cache which is executed every time pdepend is run. The
default TTL of the file cache is 30 days which results in a very large
cache directory. Scanning this cache directory for expired files in most
cases takes longer than using no cache.