### PR TITLE
1.23.0 Add temporary extension to fix validation errors of parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "mediact/composer-dependency-installer": "^1.0",
         "mediact/composer-file-installer": "^1.0",
         "mediact/composer-unclog-plugin": "^1.0",
-        "phpro/grumphp": "~0.1, !=0.18.0",
+        "phpro/grumphp": "~0.1",
         "phpstan/phpstan": "~0.1",
         "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
         "sensiolabs/security-checker": "^5.0",

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -1,4 +1,7 @@
 parameters:
+  extensions:
+    - Mediact\TestingSuite\Composer\GrumPHP\ParameterFixExtension
+
   git_dir: .
   bin_dir: vendor/bin
   ascii:
@@ -116,43 +119,3 @@ parameters:
       run_always: '%securitychecker.run_always%'
       metadata:
         priority: '%securitychecker.metadata.priority%'
-
-#    dependency-guard:
-#      metadata:
-#        priority: '%dependency-guard.metadata.priority%'
-
-#services:
-#  mediact.dependency_guard.exporter.factory:
-#    class: Mediact\DependencyGuard\Composer\Command\Exporter\ViolationExporterFactory
-#
-#  mediact.dependency_guard.exporter:
-#    class: Mediact\DependencyGuard\Exporter\ViolationExporterInterface
-#    factory: 'mediact.dependency_guard.exporter.factory:create'
-#    arguments:
-#    - '@console.input'
-#    - '@console.output'
-#
-#  mediact.dependency_guard.factory:
-#    class: Mediact\DependencyGuard\DependencyGuardFactory
-#
-#  mediact.dependency_guard.composer.io:
-#    class: Composer\IO\BufferIO
-#
-#  mediact.dependency_guard.composer.factory:
-#    class: Composer\Factory
-#
-#  mediact.dependency_guard.composer:
-#    class: Composer\Composer
-#    factory: mediact.dependency_guard.composer.factory:createComposer
-#    arguments:
-#      - '@mediact.dependency_guard.composer.io'
-#
-#  mediact.dependency_guard.grumphp.task:
-#    class: Mediact\DependencyGuard\GrumPHP\DependencyGuard
-#    arguments:
-#      - '@mediact.dependency_guard.composer'
-#      - '@mediact.dependency_guard.factory'
-#      - '@mediact.dependency_guard.exporter'
-#    tags:
-#      - name: grumphp.task
-#        config: dependency-guard

--- a/src/Factory/ProcessFactory.php
+++ b/src/Factory/ProcessFactory.php
@@ -19,6 +19,6 @@ class ProcessFactory implements ProcessFactoryInterface
      */
     public function create(string $commandLine): Process
     {
-        return new Process($commandLine);
+        return new Process([$commandLine]);
     }
 }

--- a/src/GrumPHP/ParameterFixExtension.php
+++ b/src/GrumPHP/ParameterFixExtension.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright MediaCT. All rights reserved.
+ * https://www.mediact.nl
+ */
+
+declare(strict_types=1);
+
+namespace Mediact\TestingSuite\Composer\GrumPHP;
+
+use GrumPHP\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ParameterFixExtension implements ExtensionInterface
+{
+    /**
+     * Replace placeholders to
+     * @param ContainerBuilder $container
+     *
+     * @return void
+     */
+    public function load(ContainerBuilder $container): void
+    {
+        $container->setParameter(
+            'tasks',
+            $container->resolveEnvPlaceholders(
+                $container->getParameter('tasks'),
+                true
+            )
+        );
+    }
+}

--- a/src/GrumPHP/ParameterFixExtension.php
+++ b/src/GrumPHP/ParameterFixExtension.php
@@ -11,6 +11,9 @@ namespace Mediact\TestingSuite\Composer\GrumPHP;
 use GrumPHP\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @codeCoverageIgnore
+ */
 class ParameterFixExtension implements ExtensionInterface
 {
     /**


### PR DESCRIPTION
This fixes:

```
The option "strict" with value "%composer.strict%" is expected to be of
type "bool", but is of type "string".
```

A pull request exists on https://github.com/phpro/grumphp/pull/760 which
also fixes this issue. When that pull request has been merged this
extension can be removed.