### PR TITLE
1.25.1 Disable parallel running of steps in grumphp

### DIFF
--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -48,6 +48,9 @@ grumphp:
     failed: ~
     succeeded: ~
 
+  parallel:
+    enabled: false
+
   # Default tasks for testing suite
   tasks:
     composer:


### PR DESCRIPTION
Running parallel steps requires the posix extension which is not installed on minimal docker images.