### PR TITLE
2.1.0 Enable Symfony 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpro/grumphp": ">=0.19 <1.0",
         "phpstan/phpstan": "~0.1",
         "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
-        "sensiolabs/security-checker": "^5.0"
+        "sensiolabs/security-checker": "^6.0"
     },
     "require-dev": {
         "composer/composer": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,7 @@
         "phpro/grumphp": ">=0.19 <1.0",
         "phpstan/phpstan": "~0.1",
         "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
-        "sensiolabs/security-checker": "^5.0",
-        "symfony/event-dispatcher": "^4.0",
-        "symfony/dependency-injection": "^4.0"
+        "sensiolabs/security-checker": "^5.0"
     },
     "require-dev": {
         "composer/composer": "@stable",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -2,53 +2,9 @@ imports:
   - resource: 'config/default/grumphp.yml'
 
 parameters:
-
-  # Default settings for testing suite tasks
-  composer.strict: true
-  composer.metadata.priority: 1400
-
-  jsonlint.detect_key_conflicts: true
-  jsonlint.metadata.priority: 1200
-
-  xmllint.load_from_net: true
-  xmllint.x_include: true
-  xmllint.dtd_validation: true
-  xmllint.scheme_validation: true
-  xmllint.triggered_by: [xml]
   xmllint.ignore_patterns:
-    # Uses an incomplete definition, which conflicts when <exclude-pattern>
-    # is defined.
     - /^phpcs.xml$/
     - /^phpmd.xml$/
-  xmllint.metadata.priority: 1200
-
-  yamllint.parse_constant: true
-  yamllint.metadata.priority: 1200
-
-  phpcs.standard: ./phpcs.xml
-  phpcs.triggered_by: [php]
-  phpcs.metadata.priority: 1000
-
-  phpmd.exclude: []
-  phpmd.ruleset:
-    - ./phpmd.xml
-  phpmd.triggered_by: [php]
-  phpmd.metadata.priority: 800
-
-  phpstan.autoload_file: ~
-  phpstan.configuration: ./phpstan.neon
-  phpstan.level: 4
-  phpstan.triggered_by: [php]
-  phpstan.metadata.priority: 600
-
-  phpunit.config_file: ./phpunit.xml
-  phpunit.metadata.priority: 400
-
-  securitychecker.lockfile: ./composer.lock
-  securitychecker.format: ~
-  securitychecker.end_point: ~
-  securitychecker.timeout: ~
-  securitychecker.run_always: true
-  securitychecker.metadata.priority: 200
-
-  dependency-guard.metadata.priority: 100
+    - /^phpunit.xml$/
+    - /^pdepend.xml$/
+    - /^templates/

--- a/pdepend.xml
+++ b/pdepend.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<symfony:container xmlns:symfony="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://pdepend.org/schema/dic/pdepend"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <config>
+        <cache>
+            <driver>memory</driver>
+        </cache>
+    </config>
+</symfony:container>

--- a/src/ConfigResolver.php
+++ b/src/ConfigResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/Factory/ProcessFactory.php
+++ b/src/Factory/ProcessFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/Factory/ProcessFactoryInterface.php
+++ b/src/Factory/ProcessFactoryInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/GrumPHP/ParameterFixExtension.php
+++ b/src/GrumPHP/ParameterFixExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/Installer/ArchiveExcludeInstaller.php
+++ b/src/Installer/ArchiveExcludeInstaller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -97,7 +98,8 @@ class ArchiveExcludeInstaller implements InstallerInterface
         );
 
         foreach ($files as $file) {
-            if (!in_array($file, $excluded)
+            if (
+                !in_array($file, $excluded)
                 && file_exists($this->destination . $file)
             ) {
                 $excluded[] = $file;

--- a/src/Installer/ConfigInstaller.php
+++ b/src/Installer/ConfigInstaller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/Installer/FilesInstaller.php
+++ b/src/Installer/FilesInstaller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/Installer/InstallerInterface.php
+++ b/src/Installer/InstallerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/Installer/PackagesInstaller.php
+++ b/src/Installer/PackagesInstaller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/Installer/PipelinesInstaller.php
+++ b/src/Installer/PipelinesInstaller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -75,7 +76,8 @@ class PipelinesInstaller implements InstallerInterface
      */
     public function install()
     {
-        if (file_exists($this->destination . '/' . $this->filename)
+        if (
+            file_exists($this->destination . '/' . $this->filename)
             || !$this->isBitbucket()
         ) {
             return;

--- a/src/MappingResolver.php
+++ b/src/MappingResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/src/ProjectTypeResolver.php
+++ b/src/ProjectTypeResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -16,12 +17,12 @@ class ProjectTypeResolver
     /**
      * The key from the composer configuration which contains other configuration.
      */
-    const COMPOSER_CONFIG_KEY = 'mediact-testing-suite';
+    public const COMPOSER_CONFIG_KEY = 'mediact-testing-suite';
 
     /**
      * The key in the configuration, which determines the overwrite for the type.
      */
-    const COMPOSER_CONFIG_TYPE_KEY = 'type';
+    public const COMPOSER_CONFIG_TYPE_KEY = 'type';
 
     /** @var Composer */
     private $composer;

--- a/src/installers.php
+++ b/src/installers.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/ConfigResolverTest.php
+++ b/tests/ConfigResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/Factory/ProcessFactoryTest.php
+++ b/tests/Factory/ProcessFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/Installer/ArchiveExcludeInstallerTest.php
+++ b/tests/Installer/ArchiveExcludeInstallerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/Installer/ConfigInstallerTest.php
+++ b/tests/Installer/ConfigInstallerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/Installer/FilesInstallerTest.php
+++ b/tests/Installer/FilesInstallerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/Installer/PackagesInstallerTest.php
+++ b/tests/Installer/PackagesInstallerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/Installer/PipelinesInstallerTest.php
+++ b/tests/Installer/PipelinesInstallerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/MappingResolverTest.php
+++ b/tests/MappingResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright Mediact. All rights reserved.
  * https://www.Mediact.nl

--- a/tests/ProjectTypeResolverTest.php
+++ b/tests/ProjectTypeResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl


### PR DESCRIPTION
The Symfony 4.x dependencies have been added previously to prevent problems with GrumPHP and Symfony 5.x. These problems should be fixed by now.

Requiring 4.x was causing problems because composer would sometimes prefer a newer version of Symfony over the testing suite causing an old version of the testing suite to be installed.