### PR TITLE
2.2.0 Allow any stable version of test libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,16 @@
     "require": {
         "php": "^7.1",
         "composer-plugin-api": "^1.1",
-        "kint-php/kint": "~1.0 || ~2.0 || ~3.0",
-        "mediact/coding-standard": "~1.0 || ~2.0 || ~3.0",
-        "mediact/coding-standard-phpstorm": "~1.0 || ~2.0",
+        "kint-php/kint": "@stable",
+        "mediact/coding-standard": "@stable",
+        "mediact/coding-standard-phpstorm": "@stable",
         "mediact/composer-dependency-installer": "^1.0",
         "mediact/composer-file-installer": "^1.0",
         "mediact/composer-unclog-plugin": "^1.0",
-        "phpro/grumphp": ">=0.19 <1.0",
-        "phpstan/phpstan": "~0.1",
-        "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
-        "sensiolabs/security-checker": "^6.0"
+        "phpro/grumphp": "@stable",
+        "phpstan/phpstan": "@stable",
+        "phpunit/phpunit": "@stable",
+        "sensiolabs/security-checker": "@stable"
     },
     "require-dev": {
         "composer/composer": "@stable",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -2,6 +2,7 @@ imports:
   - resource: 'config/default/grumphp.yml'
 
 parameters:
+  composer.strict: false
   xmllint.ignore_patterns:
     - /^phpcs.xml$/
     - /^phpmd.xml$/


### PR DESCRIPTION
The test libraries should be kept up-to-date to prevent large changes.
Because of the old version requirements PHPUnit was never updated.