### PR TITLE
Fix bad constructor.

### DIFF
--- a/src/Factory/ProcessFactory.php
+++ b/src/Factory/ProcessFactory.php
@@ -22,6 +22,6 @@ class ProcessFactory implements ProcessFactoryInterface
     {
         return method_exists(Process::class, 'fromShellCommandline')
             ? Process::fromShellCommandline($commandLine)
-            : new Process($commandLine);
+            : new Process([$commandLine]);
     }
 }


### PR DESCRIPTION
In release 1.23.1 a change was done to how processes are constructed, however the else clause of the ternary operator now contains a bad construct. (See: https://github.com/mediact/testing-suite/pull/43/files)