### PR TITLE
In Symfony <4.x the constructor of Process should take a string

### DIFF
--- a/src/Factory/ProcessFactory.php
+++ b/src/Factory/ProcessFactory.php
@@ -21,7 +21,7 @@ class ProcessFactory implements ProcessFactoryInterface
     public function create(string $commandLine): Process
     {
         return method_exists(Process::class, 'fromShellCommandline')
-            ? Process::fromShellCommandline($commandLine)
-            : new Process([$commandLine]);
+            ? Process::fromShellCommandline($commandLine) // Symfony 5.x
+            : new Process($commandLine); // Symfony <=4.x (see https://github.com/composer/composer/blob/1.10.17/src/Composer/Util/ProcessExecutor.php#L68:L72)
     }
 }

--- a/src/Factory/ProcessFactory.php
+++ b/src/Factory/ProcessFactory.php
@@ -21,7 +21,7 @@ class ProcessFactory implements ProcessFactoryInterface
     public function create(string $commandLine): Process
     {
         return method_exists(Process::class, 'fromShellCommandline')
-            ? Process::fromShellCommandline($commandLine) // Symfony 5.x
-            : new Process($commandLine); // Symfony <=4.x (see https://github.com/composer/composer/blob/1.10.17/src/Composer/Util/ProcessExecutor.php#L68:L72)
+            ? Process::fromShellCommandline($commandLine) // Symfony >= 4.2
+            : new Process($commandLine); // Symfony < 4.2 (see https://github.com/composer/composer/blob/1.10.17/src/Composer/Util/ProcessExecutor.php#L68:L72)
     }
 }


### PR DESCRIPTION
This rolls back https://github.com/mediact/testing-suite/pull/50

When using an 1.10.x PHAR of composer the included Symfony Process implementation can not handle an array in it's constructor. I'm not sure what the exact Symfony version is but I see messages about functionality being deprecated in 2.5, so I assume it's Symfony 2.7.

The version that can only handle an array is 5.x but that version is already covered by checking for the method `fromShellCommandline`. For a similar check see https://github.com/composer/composer/blob/1.10.17/src/Composer/Util/ProcessExecutor.php#L68:L72.