### PR TITLE
Install Enlightn Security Checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.1",
         "composer-plugin-api": "^1.1 || ^2.0",
+        "enlightn/security-checker": "^1.5",
         "kint-php/kint": "@stable",
         "mediact/coding-standard": "@stable",
         "mediact/coding-standard-phpstorm": "@stable",
@@ -30,7 +31,8 @@
         "mediact/composer-unclog-plugin": "^1.0",
         "phpro/grumphp": ">=0.19 <1.0",
         "phpstan/phpstan": "@stable",
-        "phpunit/phpunit": "@stable"
+        "phpunit/phpunit": "@stable",
+        "ext-zip": "*"
     },
     "require-dev": {
         "composer/composer": "@stable",

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -35,9 +35,6 @@ parameters:
   phpunit.config_file: ./phpunit.xml
 
   securitychecker.lockfile: ./composer.lock
-  securitychecker.format: ~
-  securitychecker.end_point: ~
-  securitychecker.timeout: ~
   securitychecker.run_always: true
 
 grumphp:
@@ -87,3 +84,7 @@ grumphp:
 
     phpunit:
       config_file: '%phpunit.config_file%'
+
+    securitychecker:
+      lockfile: '%securitychecker.lockfile%'
+      run_always: '%securitychecker.run_always%'


### PR DESCRIPTION
To replace the Symfony Security Checker, the Enlightn Security
Checker has been installed, which does the same checks and is
already enabled in the GrumPHP configuration.

See: https://github.com/phpro/grumphp/issues/865