### PR TITLE
Implement Git Blacklist checks

### DIFF
--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -44,10 +44,10 @@ parameters:
   securitychecker.run_always: true
 
   git_blacklist.keywords:
-    - "die\\("
-    - "var_dump\\("
+    - "die("
+    - "var_dump("
     - "exit;"
-    - "Magento\\Framework\\App\\ObjectManager"
+    - "Magento\\\\Framework\\\\App\\\\ObjectManager"
   git_blacklist.whitelist_patterns: []
   git_blacklist.triggered_by: [ 'php' ]
   git_blacklist.regexp_type: G

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -40,6 +40,16 @@ parameters:
   securitychecker.timeout: ~
   securitychecker.run_always: true
 
+  git_blacklist.keywords:
+    - "die\\("
+    - "var_dump\\("
+    - "exit;"
+    - "Magento\\Framework\\App\\ObjectManager"
+  git_blacklist.whitelist_patterns: []
+  git_blacklist.triggered_by: [ 'php' ]
+  git_blacklist.regexp_type: G
+  git_blacklist.match_word: false
+
 grumphp:
   extensions:
     - Mediact\TestingSuite\Composer\GrumPHP\ParameterFixExtension
@@ -49,7 +59,7 @@ grumphp:
     succeeded: ~
 
   parallel:
-    enabled: false
+    enabled: true
 
   # Default tasks for testing suite
   tasks:
@@ -58,6 +68,13 @@ grumphp:
 
     jsonlint:
       detect_key_conflicts: '%jsonlint.detect_key_conflicts%'
+
+    git_blacklist:
+      keywords: '%git_blacklist.keywords%'
+      whitelist_patterns: '%git_blacklist.whitelist_patterns%'
+      triggered_by: '%git_blacklist.triggered_by%'
+      regexp_type: '%git_blacklist.regexp_type%'
+      match_word: '%git_blacklist.match_word%'
 
     xmllint:
       load_from_net: '%xmllint.load_from_net%'


### PR DESCRIPTION
The Git Blacklist checks have been implemented to prevent code
to contain `die(`, `var_dump(`, `exit` or `ObjectManager::`. These
scripts are not wanted on production ready code.