### PR TITLE
Replace Sensiolabs/security-checker *

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "composer/composer": "@stable",
         "mikey179/vfsstream": "@stable"
     },
+    "replace": {
+        "sensiolabs/security-checker": "*"
+    },
     "bin": [
         "bin/mediact-testing-suite"
     ],


### PR DESCRIPTION
The Sensiolabs/security-checker causes the actually required library to be skipped.