### PR TITLE
Add Magento projects to project type mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Depending on the composer type of the project an other standard will be used:
 
 - `magento-module`: [MediaCT Coding Standard Magento1](https://github.com/mediact/coding-standard-magento1)
 - `magento2-module`: [MediaCT Coding Standard Magento2](https://github.com/mediact/coding-standard-magento2)
+- `magento-project`: [MediaCT Coding Standard Magento1](https://github.com/mediact/coding-standard-magento1)
+- `magento2-project`: [MediaCT Coding Standard Magento2](https://github.com/mediact/coding-standard-magento2)
 
 ### Overriding the type
 

--- a/src/ProjectTypeResolver.php
+++ b/src/ProjectTypeResolver.php
@@ -30,7 +30,9 @@ class ProjectTypeResolver
     /** @var array */
     private $mapping = [
         'magento2-module' => 'magento2',
-        'magento-module'  => 'magento1'
+        'magento-module'  => 'magento1',
+        'magento2-project' => 'magento2',
+        'magento-project' => 'magento2'
     ];
 
     /**
@@ -53,6 +55,7 @@ class ProjectTypeResolver
     public function resolve(): string
     {
         $config = $this->composer->getConfig();
+
         if ($config->has(static::COMPOSER_CONFIG_KEY)) {
             $configNode = $config->get(static::COMPOSER_CONFIG_KEY);
             if (isset($configNode[static::COMPOSER_CONFIG_TYPE_KEY])) {


### PR DESCRIPTION
To make it easier to install the testing suite for Magento, it's
now possible to set the project type in the project's composer.json
file to `magento2-project` or `magento-project` to get the correct
coding standards files in the project.