### PR TITLE
Install Enlightn Security Checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.1",
         "composer-plugin-api": "^1.1",
+        "enlightn/security-checker": "^1.5",
         "kint-php/kint": "~1.0 || ~2.0 || ~3.0",
         "mediact/coding-standard": "~1.0 || ~2.0",
         "mediact/coding-standard-phpstorm": "~1.0 || ~2.0",
@@ -31,9 +32,9 @@
         "phpro/grumphp": ">=0.19 <1.0",
         "phpstan/phpstan": "~0.1",
         "phpunit/phpunit": "~3.7 || ~4.0 || ~5.0 || ~6.0 || ~7.0 || ~8.0",
-        "sensiolabs/security-checker": "^5.0",
         "symfony/event-dispatcher": "^4.0",
-        "symfony/dependency-injection": "^4.0"
+        "symfony/dependency-injection": "^4.0",
+        "ext-zip": "*"
     },
     "require-dev": {
         "composer/composer": "@stable",

--- a/config/default/grumphp.yml
+++ b/config/default/grumphp.yml
@@ -35,9 +35,6 @@ parameters:
   phpunit.config_file: ./phpunit.xml
 
   securitychecker.lockfile: ./composer.lock
-  securitychecker.format: ~
-  securitychecker.end_point: ~
-  securitychecker.timeout: ~
   securitychecker.run_always: true
 
 grumphp:
@@ -90,7 +87,4 @@ grumphp:
 
     securitychecker:
       lockfile: '%securitychecker.lockfile%'
-      format: '%securitychecker.format%'
-      end_point: '%securitychecker.end_point%'
-      timeout: '%securitychecker.timeout%'
       run_always: '%securitychecker.run_always%'


### PR DESCRIPTION
To replace the Symfony Security Checker, the Enlightn Security
Checker has been installed, which does the same checks and is
already enabled in the GrumPHP configuration.

See: https://github.com/phpro/grumphp/issues/865